### PR TITLE
Remove top-level permissions from claude-fix workflow

### DIFF
--- a/.github/workflows/claude-fix.yml
+++ b/.github/workflows/claude-fix.yml
@@ -4,13 +4,6 @@ on:
   issue_comment:
     types: [created]
 
-permissions:
-  contents: write
-  pull-requests: write
-  issues: write
-  actions: read
-  id-token: write
-
 jobs:
   fix:
     if: |

--- a/rclient/src/components/CanvasEditor.tsx
+++ b/rclient/src/components/CanvasEditor.tsx
@@ -172,7 +172,7 @@ const CanvasEditor = forwardRef(function CanvasEditor(
     }
   };
 
-  async function drawOnCanvas(
+  function drawOnCanvas(
     x: number,
     y: number,
     color: RGBHEX,


### PR DESCRIPTION
## Summary
- Remove top-level permissions block from claude-fix.yml to avoid conflicts with GitHub App token
- Keep only job-level permissions

## Test plan
- [ ] Comment `@claude` on this PR to verify fix workflow can push commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)